### PR TITLE
Platform class derives package name via a hardcoded string

### DIFF
--- a/src/main/java/com/kenai/constantine/Platform.java
+++ b/src/main/java/com/kenai/constantine/Platform.java
@@ -36,10 +36,9 @@ public class Platform {
     }
 
     static String getConstantsPackageName() {
-        Package pkg = Platform.class.getPackage();
-        return pkg != null
-                ? pkg.getName()
-                : Platform.class.getName().substring(0, Platform.class.getName().lastIndexOf('.'));
+        // Determining this dynamically fails if jarjar is used, so hardcode instead
+        // Update this if you change the package name or refactor this class
+        return "com.kenai.constantine";
     }
 
     public String getPackageName() {

--- a/src/test/java/com/kenai/constantine/PlatformTest.java
+++ b/src/test/java/com/kenai/constantine/PlatformTest.java
@@ -1,0 +1,14 @@
+package com.kenai.constantine;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+public class PlatformTest {
+
+    @Test
+    public void testPlatformPackageName() {
+        Assert.assertEquals("Package name for platform class is hard-coded but no longer matches",
+            Platform.getConstantsPackageName(), Platform.class.getPackage().getName());
+    }
+}


### PR DESCRIPTION
Otherwise, when included in a jar using jarjar or other tools, causes
NPEs.  Solves problems described at the links below

* http://www.ruby-forum.com/topic/211334
* http://www.ruby-forum.com/topic/2321320
* https://github.com/jnr/jnr-constants/issues/1