### PR TITLE
Make fake constant values optional via a system property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: java
 jdk:
   - oraclejdk7
   - openjdk6
+script:
+  - mvn test -B
+  - mvn test -B -Djnr.constants.fake=false

--- a/src/main/java/jnr/constants/Platform.java
+++ b/src/main/java/jnr/constants/Platform.java
@@ -48,12 +48,21 @@ public final class Platform {
         return PackageNameResolver.PACKAGE_NAME;
     }
 
+    public static final boolean FAKE = Boolean.valueOf(System.getProperty("jnr.constants.fake", "true"));
+
     public String[] getPackagePrefixes() {
-        return new String[] {
-            getArchPackageName(),
-            getOSPackageName(),
-            getFakePackageName(),
-        };
+        if (FAKE) {
+            return new String[] {
+                    getArchPackageName(),
+                    getOSPackageName(),
+                    getFakePackageName(),
+            };
+        } else {
+            return new String[] {
+                    getArchPackageName(),
+                    getOSPackageName(),
+            };
+        }
     }
 
     public String getArchPackageName() {

--- a/src/main/java/jnr/constants/platform/ConstantResolver.java
+++ b/src/main/java/jnr/constants/platform/ConstantResolver.java
@@ -17,6 +17,8 @@ package jnr.constants.platform;
 import jnr.constants.platform.*;
 import jnr.constants.Constant;
 import jnr.constants.ConstantSet;
+import jnr.constants.Platform;
+
 import java.lang.reflect.Array;
 import java.util.EnumSet;
 import java.util.Map;
@@ -70,14 +72,17 @@ class ConstantResolver<E extends Enum<E>> {
         }
 
         public int value() {
+            checkFake();
             return (int) value;
         }
 
         public final int intValue() {
+            checkFake();
             return (int) value;
         }
 
         public final long longValue() {
+            checkFake();
             return value;
         }
 
@@ -92,6 +97,12 @@ class ConstantResolver<E extends Enum<E>> {
         @Override
         public final String toString() {
             return name;
+        }
+
+        private void checkFake() {
+            if (!Platform.FAKE) {
+                throw new AssertionError("Constant " + name + " is not defined on " + Platform.NAME);
+            }
         }
     }
 

--- a/src/test/java/jnr/constants/DefinedTest.java
+++ b/src/test/java/jnr/constants/DefinedTest.java
@@ -57,4 +57,22 @@ public class DefinedTest {
             Assert.assertTrue(LangInfo.CODESET.defined());
         }
     }
+
+    @Test
+    public void testUndefinedConstant() throws Throwable {
+        if (Platform.OS.equals("linux")) {
+            Assert.assertFalse(AddressFamily.AF_CHAOS.defined());
+            if (Platform.FAKE) {
+                Assert.assertTrue(AddressFamily.AF_CHAOS.intValue() >= 20000);
+
+            } else {
+                try {
+                    AddressFamily.AF_CHAOS.intValue();
+                    Assert.fail();
+                } catch (AssertionError e) {
+                    Assert.assertTrue(true);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
* Throws an AssertionError when trying to get the value of an undefined constant.

The idea is that it's very easy to access constants values and forget to check with `defined()` and this can help to catch these wrong usages when they happen, before being passed to a native call or so.

cc @nirvdrum @headius @chrisseaton