### PR TITLE
[build] fix env flags

### DIFF
--- a/gen/const_generator.rb
+++ b/gen/const_generator.rb
@@ -129,7 +129,10 @@ module Constantine
         f.puts "\n\treturn 0;\n}"
         f.flush
 
-        output = `$CC #{options[:cppflags]} $CFLAGS -D_DARWIN_USE_64_BIT_INODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -x c -Wall -Werror #{f.path} -o #{binary} $LDFLAGS 2>&1`
+        cflags = ENV['CFLAGS']
+        ldflags = ENV['LDFLAGS']
+        cc = ENV['CC'] || 'gcc'
+        output = `#{cc} #{options[:cppflags]} #{cflags} -D_DARWIN_USE_64_BIT_INODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -x c -Wall -Werror #{f.path} -o #{binary} #{ldflags} 2>&1`
 
         unless $?.success? then
           output = output.split("\n").map { |l| "\t#{l}" }.join "\n"


### PR DESCRIPTION
1/ use gcc as a fallback if ENV['CC'] is undefined
2/ $ isn't vailid in windows shell, use ENV variables instead