### PR TITLE
explicit cast to long int

### DIFF
--- a/gen/const/LastError.rb
+++ b/gen/const/LastError.rb
@@ -153,6 +153,6 @@ def gen_lasterror_java(options)
       WSANO_RECOVERY
       WSANO_DATA
     ]
-    consts.each { |c| cg.const(c, '%ld') }
+    consts.each { |c| cg.const(c, '%ld', '(long int)') }
   end
 end


### PR DESCRIPTION
```
error: format '%li' expects argument of type 'long int', but argument 2 has type 'int' [-Werror=format=]
```