### PR TITLE
generate all architecture constants on x86

### DIFF
--- a/scripts/autogen.sh
+++ b/scripts/autogen.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+ARCHS=(
+x86_64
+aarch64
+mips64el
+ppc64le
+s390x
+)
+
+
+regen_arch(){
+    docker run -v $(pwd):$(pwd) merore/jnr-multiarch-env:$1 \
+	    /bin/bash -c "cd $(pwd) && rake regen:lplatform"
+}
+
+regen_all_arch(){
+    for arch in ${ARCHS[@]}; do
+        regen_arch $arch
+    done
+}
+
+if [ $# == 0 ]
+then
+    regen_all_arch
+elif [[ $# == 1 && ${ARCHS[@]/$1/} != ${ARCH[@]} ]]
+then
+	regen_arch $1
+else
+	echo ''
+	echo './scripts/autogen.sh		regenerate all platform constants'
+	echo './scriptes/autogen.sh $ARCH	regenerate constants for the specified platform'
+	echo ""
+fi


### PR DESCRIPTION
I built [docker image](https://github.com/merore/jnr-multiarch-env) for jnr to run and test with multiarch on x86. `autogen.sh` can use this image to generate all architecture constants on x86.

You must add `bitfmt_misc` for system before running this scripts. A simple way is to run `docker run --rm --privileged multiarch/qemu-user-static`

Instructions:
`./scritps/autogen.sh` regenerate all platform constants
`./scriptes/autogen.sh aarch64` regenerate constants for the specified platform

In the future, I plan to use this images to test of jnr-posix, etc. 